### PR TITLE
Add packages used in the Planetary Computer tutorials

### DIFF
--- a/runtime/environment-cpu.yml
+++ b/runtime/environment-cpu.yml
@@ -14,8 +14,8 @@ dependencies:
   - keras=2.4.3
   - loguru=0.5.3
   - mkl=2020.4
+  - numpy=1.20.3
   - numba=0.54.1
-  - numpy=1.20.0
   - pandas=1.3.1
   - pillow=8.2.0
   - pip=20.3.4

--- a/runtime/environment-cpu.yml
+++ b/runtime/environment-cpu.yml
@@ -43,7 +43,6 @@ dependencies:
   - tqdm=4.62.0
   - typer=0.3.2
   - xarray=0.19.0
-  - xarray-spatial=0.3.0
   - pip:
     - cloudpathlib[azure]==0.6.2
     - lightning-flash[image]==0.5.0

--- a/runtime/environment-cpu.yml
+++ b/runtime/environment-cpu.yml
@@ -14,8 +14,8 @@ dependencies:
   - keras=2.4.3
   - loguru=0.5.3
   - mkl=2020.4
-  - numpy=1.20.3
   - numba=0.54.1
+  - numpy=1.20.0
   - pandas=1.3.1
   - pillow=8.2.0
   - pip=20.3.4
@@ -24,7 +24,7 @@ dependencies:
   - pyepsg=0.4.0
   - pygeos=0.10.1
   - pyproj=3.3.0
-  - pystac-client
+  - pystac-client=0.3.1
   - pytest=6.2.4
   - python=3.9.7
   - pytorch-cpu=1.8.0
@@ -35,7 +35,7 @@ dependencies:
   - scipy=1.7.1
   - segmentation-models-pytorch=0.2.0
   - shapely=1.7.1
-  - stackstac
+  - stackstac=0.2.2
   - tifffile=2021.8.8
   - tiledb=2.3.2
   - timm=0.4.12
@@ -43,7 +43,7 @@ dependencies:
   - tqdm=4.62.0
   - typer=0.3.2
   - xarray=0.19.0
-  - xarray-spatial
+  - xarray-spatial=0.3.0
   - pip:
     - cloudpathlib[azure]==0.6.2
     - lightning-flash[image]==0.5.0

--- a/runtime/environment-cpu.yml
+++ b/runtime/environment-cpu.yml
@@ -24,6 +24,7 @@ dependencies:
   - pyepsg=0.4.0
   - pygeos=0.10.1
   - pyproj=3.3.0
+  - pystac-client
   - pytest=6.2.4
   - python=3.9.7
   - pytorch-cpu=1.8.0
@@ -34,6 +35,7 @@ dependencies:
   - scipy=1.7.1
   - segmentation-models-pytorch=0.2.0
   - shapely=1.7.1
+  - stackstac
   - tifffile=2021.8.8
   - tiledb=2.3.2
   - timm=0.4.12
@@ -41,6 +43,7 @@ dependencies:
   - tqdm=4.62.0
   - typer=0.3.2
   - xarray=0.19.0
+  - xarray-spatial
   - pip:
     - cloudpathlib[azure]==0.6.2
     - lightning-flash[image]==0.5.0

--- a/runtime/environment-gpu.yml
+++ b/runtime/environment-gpu.yml
@@ -17,8 +17,8 @@ dependencies:
   - keras=2.4.3
   - loguru=0.5.3
   - mkl=2020.4
+  - numpy=1.20.3
   - numba=0.54.1
-  - numpy=1.20.0
   - pandas=1.3.1
   - pillow=8.2.0
   - pip=20.3.4

--- a/runtime/environment-gpu.yml
+++ b/runtime/environment-gpu.yml
@@ -46,7 +46,6 @@ dependencies:
   - tqdm=4.62.0
   - typer=0.3.2
   - xarray=0.19.0
-  - xarray-spatial=0.3.0
   - pip:
     - cloudpathlib[azure]==0.6.2
     - lightning-flash[image]==0.5.0

--- a/runtime/environment-gpu.yml
+++ b/runtime/environment-gpu.yml
@@ -27,6 +27,7 @@ dependencies:
   - pyepsg=0.4.0
   - pygeos=0.10.1
   - pyproj=3.3.0
+  - pystac-client
   - pytest=6.2.4
   - python=3.9.7
   - pytorch-lightning=1.4.1
@@ -37,6 +38,7 @@ dependencies:
   - scipy=1.7.1
   - segmentation-models-pytorch=0.2.0
   - shapely=1.7.1
+  - stackstac
   - tifffile=2021.8.8
   - tiledb=2.3.2
   - timm=0.4.12
@@ -44,6 +46,7 @@ dependencies:
   - tqdm=4.62.0
   - typer=0.3.2
   - xarray=0.19.0
+  - xarray-spatial
   - pip:
     - cloudpathlib[azure]==0.6.2
     - lightning-flash[image]==0.5.0

--- a/runtime/environment-gpu.yml
+++ b/runtime/environment-gpu.yml
@@ -17,8 +17,8 @@ dependencies:
   - keras=2.4.3
   - loguru=0.5.3
   - mkl=2020.4
-  - numpy=1.20.3
   - numba=0.54.1
+  - numpy=1.20.0
   - pandas=1.3.1
   - pillow=8.2.0
   - pip=20.3.4
@@ -27,7 +27,7 @@ dependencies:
   - pyepsg=0.4.0
   - pygeos=0.10.1
   - pyproj=3.3.0
-  - pystac-client
+  - pystac-client=0.3.1
   - pytest=6.2.4
   - python=3.9.7
   - pytorch-lightning=1.4.1
@@ -38,7 +38,7 @@ dependencies:
   - scipy=1.7.1
   - segmentation-models-pytorch=0.2.0
   - shapely=1.7.1
-  - stackstac
+  - stackstac=0.2.2
   - tifffile=2021.8.8
   - tiledb=2.3.2
   - timm=0.4.12
@@ -46,7 +46,7 @@ dependencies:
   - tqdm=4.62.0
   - typer=0.3.2
   - xarray=0.19.0
-  - xarray-spatial
+  - xarray-spatial=0.3.0
   - pip:
     - cloudpathlib[azure]==0.6.2
     - lightning-flash[image]==0.5.0


### PR DESCRIPTION
I'd like to use these 3 packages that often appear in the Planetary Computer tutorials:
- `pystac-client`
- `stackstac`
- `xarray-spatial`

They would make everyone's life easier if they want to use any additional data.