### PR TITLE
Adding CrfSeg Library

### DIFF
--- a/runtime/environment-cpu.yml
+++ b/runtime/environment-cpu.yml
@@ -51,3 +51,4 @@ dependencies:
     - segmentation-models==1.0.1
     - tensorflow-cpu==2.6.0
     - ttach==0.0.3
+    - crfseg==1.0.0

--- a/runtime/environment-gpu.yml
+++ b/runtime/environment-gpu.yml
@@ -54,3 +54,4 @@ dependencies:
     - segmentation-models==1.0.1
     - tensorflow-gpu==2.6.0
     - ttach==0.0.3
+    - crfseg==1.0.0


### PR DESCRIPTION
Instructions on GitHub page (https://github.com/migonch/crfseg) call for pip install, looks like only 1 version available.