### PR TITLE
Add xarray-spatial package.

### DIFF
--- a/README.md
+++ b/README.md
@@ -371,28 +371,25 @@ When you run `make test-submission` the logs will be printed to the terminal. Th
 
 ## (2) Updating the runtime packages
 
-We accept contributions to add dependencies to the runtime environment. To do so, follow these steps:
+If you want to use a package that is not in the environment, you are welcome to make a pull request to this repository. If you're new to the GitHub contribution workflow, check out [this guide by GitHub](https://docs.github.com/en/get-started/quickstart/contributing-to-projects). The runtime manages dependencies using [conda](https://docs.conda.io/en/latest/) environments. [Here is a good general guide](https://towardsdatascience.com/a-guide-to-conda-environments-bc6180fc533) to conda environments. Follow these steps:
 
-1. Fork this repository
-2. Make your changes
-3. Test them and commit using git
-3. Open a pull request to this repository
+1. Fork this repository.
+2. Edit the [conda](https://docs.conda.io/en/latest/) environment YAML files, `runtime/environment-cpu.yml` and `runtime/environment-gpu.yml`. There are two ways to add a requirement:
+ - Add an entry to the `dependencies` section. This installs from a conda channel using `conda install`. Conda performs robust dependency resolution with other packages in the `dependencies` section, so we can avoid package version conflicts.
+ - Add an entry to the `pip` section. This installs from PyPI using `pip`, and is an option for packages that are not available in a conda channel.
 
-If you're new to the GitHub contribution workflow, check out [this guide by GitHub](https://guides.github.com/activities/forking/).
+For both methods, be sure to include the exact version pin, e.g., `numpy==1.20.3`, so that we can be sure that all environments use the exact same package versions.
 
-### Adding new Python packages
+3. Locally test that the Docker image builds successfully for CPU and GPU images by running:
 
-We use [conda](https://docs.conda.io/en/latest/) to manage Python dependencies. Add your new dependencies to both `runtime/environment-cpu.yml` and `runtime/environment-gpu.yml`.
-
-Your new dependency should follow the format in the yml.
-
-### Opening a pull request
-
-After making and testing your changes, commit your changes and push to your fork. Then, when viewing the repository on github.com, you will see a banner that lets you open the pull request. For more detailed instructions, check out [GitHub's help page](https://help.github.com/en/articles/creating-a-pull-request-from-a-fork).
-
-Once you open the pull request, Github Actions will automatically try building the Docker images with your changes and run the tests in `runtime/tests`. These tests can take up to 30 minutes to run through, and may take longer if your build is queued behind others. You will see a section on the pull request page that shows the status of the tests and links to the logs.
-
-You may be asked to submit revisions to your pull request if the tests fail, or if a DrivenData team member asks for revisions. Pull requests won't be merged until all tests pass and the team has reviewed and approved the changes.
+```sh
+CPU_OR_GPU=cpu make build
+CPU_OR_GPU=gpu make build
+```
+4. Commit your changes to your fork.
+5. Open a pull request from your branch to the `main` branch of this repository. Navigate to the [Pull requests](https://github.com/drivendataorg/cloud-cover-runtime/pulls) tab in this repository, and click the "New pull request" button. For more detailed instructions, check out [GitHub's help page](https://help.github.com/en/articles/creating-a-pull-request-from-a-fork).
+6. Once you open the pull request, Github Actions will automatically try building the Docker images with your changes and run the tests in `runtime/tests`. These tests can take up to 30 minutes to run through, and may take longer if your build is queued behind others. You will see a section on the pull request page that shows the status of the tests and links to the logs.
+7. You may be asked to submit revisions to your pull request if the tests fail, or if a DrivenData team member asks for revisions. Pull requests won't be merged until all tests pass and the team has reviewed and approved the changes.
 
 ---
 

--- a/runtime/environment-cpu.yml
+++ b/runtime/environment-cpu.yml
@@ -14,8 +14,8 @@ dependencies:
   - keras=2.4.3
   - loguru=0.5.3
   - mkl=2020.4
+  - numpy=1.20.3
   - numba=0.54.1
-  - numpy=1.20.0
   - pandas=1.3.1
   - pillow=8.2.0
   - pip=20.3.4

--- a/runtime/environment-cpu.yml
+++ b/runtime/environment-cpu.yml
@@ -43,7 +43,6 @@ dependencies:
   - tqdm=4.62.0
   - typer=0.3.2
   - xarray=0.19.0
-  - xarray-spatial=0.3.0
   - pip:
     - cloudpathlib[azure]==0.6.2
     - lightning-flash[image]==0.5.0

--- a/runtime/environment-cpu.yml
+++ b/runtime/environment-cpu.yml
@@ -53,3 +53,4 @@ dependencies:
     - segmentation-models==1.0.1
     - tensorflow-cpu==2.6.0
     - ttach==0.0.3
+    - xarray-spatial==0.3.0

--- a/runtime/environment-cpu.yml
+++ b/runtime/environment-cpu.yml
@@ -14,8 +14,8 @@ dependencies:
   - keras=2.4.3
   - loguru=0.5.3
   - mkl=2020.4
-  - numpy=1.20.3
   - numba=0.54.1
+  - numpy=1.20.0
   - pandas=1.3.1
   - pillow=8.2.0
   - pip=20.3.4
@@ -24,7 +24,7 @@ dependencies:
   - pyepsg=0.4.0
   - pygeos=0.10.1
   - pyproj=3.3.0
-  - pystac-client
+  - pystac-client=0.3.1
   - pytest=6.2.4
   - python=3.9.7
   - pytorch-cpu=1.8.0
@@ -35,7 +35,7 @@ dependencies:
   - scipy=1.7.1
   - segmentation-models-pytorch=0.2.0
   - shapely=1.7.1
-  - stackstac
+  - stackstac=0.2.2
   - tifffile=2021.8.8
   - tiledb=2.3.2
   - timm=0.4.12
@@ -43,7 +43,7 @@ dependencies:
   - tqdm=4.62.0
   - typer=0.3.2
   - xarray=0.19.0
-  - xarray-spatial
+  - xarray-spatial=0.3.0
   - pip:
     - cloudpathlib[azure]==0.6.2
     - lightning-flash[image]==0.5.0

--- a/runtime/environment-cpu.yml
+++ b/runtime/environment-cpu.yml
@@ -24,6 +24,7 @@ dependencies:
   - pyepsg=0.4.0
   - pygeos=0.10.1
   - pyproj=3.3.0
+  - pystac-client
   - pytest=6.2.4
   - python=3.9.7
   - pytorch-cpu=1.8.0
@@ -34,6 +35,7 @@ dependencies:
   - scipy=1.7.1
   - segmentation-models-pytorch=0.2.0
   - shapely=1.7.1
+  - stackstac
   - tifffile=2021.8.8
   - tiledb=2.3.2
   - timm=0.4.12
@@ -41,6 +43,7 @@ dependencies:
   - tqdm=4.62.0
   - typer=0.3.2
   - xarray=0.19.0
+  - xarray-spatial
   - pip:
     - cloudpathlib[azure]==0.6.2
     - lightning-flash[image]==0.5.0

--- a/runtime/environment-gpu.yml
+++ b/runtime/environment-gpu.yml
@@ -17,8 +17,8 @@ dependencies:
   - keras=2.4.3
   - loguru=0.5.3
   - mkl=2020.4
+  - numpy=1.20.3
   - numba=0.54.1
-  - numpy=1.20.0
   - pandas=1.3.1
   - pillow=8.2.0
   - pip=20.3.4

--- a/runtime/environment-gpu.yml
+++ b/runtime/environment-gpu.yml
@@ -46,7 +46,6 @@ dependencies:
   - tqdm=4.62.0
   - typer=0.3.2
   - xarray=0.19.0
-  - xarray-spatial=0.3.0
   - pip:
     - cloudpathlib[azure]==0.6.2
     - lightning-flash[image]==0.5.0

--- a/runtime/environment-gpu.yml
+++ b/runtime/environment-gpu.yml
@@ -27,6 +27,7 @@ dependencies:
   - pyepsg=0.4.0
   - pygeos=0.10.1
   - pyproj=3.3.0
+  - pystac-client
   - pytest=6.2.4
   - python=3.9.7
   - pytorch-lightning=1.4.1
@@ -37,6 +38,7 @@ dependencies:
   - scipy=1.7.1
   - segmentation-models-pytorch=0.2.0
   - shapely=1.7.1
+  - stackstac
   - tifffile=2021.8.8
   - tiledb=2.3.2
   - timm=0.4.12
@@ -44,6 +46,7 @@ dependencies:
   - tqdm=4.62.0
   - typer=0.3.2
   - xarray=0.19.0
+  - xarray-spatial
   - pip:
     - cloudpathlib[azure]==0.6.2
     - lightning-flash[image]==0.5.0

--- a/runtime/environment-gpu.yml
+++ b/runtime/environment-gpu.yml
@@ -56,3 +56,4 @@ dependencies:
     - segmentation-models==1.0.1
     - tensorflow-gpu==2.6.0
     - ttach==0.0.3
+    - xarray-spatial==0.3.0

--- a/runtime/environment-gpu.yml
+++ b/runtime/environment-gpu.yml
@@ -17,8 +17,8 @@ dependencies:
   - keras=2.4.3
   - loguru=0.5.3
   - mkl=2020.4
-  - numpy=1.20.3
   - numba=0.54.1
+  - numpy=1.20.0
   - pandas=1.3.1
   - pillow=8.2.0
   - pip=20.3.4
@@ -27,7 +27,7 @@ dependencies:
   - pyepsg=0.4.0
   - pygeos=0.10.1
   - pyproj=3.3.0
-  - pystac-client
+  - pystac-client=0.3.1
   - pytest=6.2.4
   - python=3.9.7
   - pytorch-lightning=1.4.1
@@ -38,7 +38,7 @@ dependencies:
   - scipy=1.7.1
   - segmentation-models-pytorch=0.2.0
   - shapely=1.7.1
-  - stackstac
+  - stackstac=0.2.2
   - tifffile=2021.8.8
   - tiledb=2.3.2
   - timm=0.4.12
@@ -46,7 +46,7 @@ dependencies:
   - tqdm=4.62.0
   - typer=0.3.2
   - xarray=0.19.0
-  - xarray-spatial
+  - xarray-spatial=0.3.0
   - pip:
     - cloudpathlib[azure]==0.6.2
     - lightning-flash[image]==0.5.0


### PR DESCRIPTION
Follow-up on https://github.com/drivendataorg/cloud-cover-runtime/pull/11, which adds `xarray-spatial` in the `pip` section. Docker seems to build images successfully now.