### PR TITLE
Fix keras version bug

### DIFF
--- a/runtime/environment-cpu.yml
+++ b/runtime/environment-cpu.yml
@@ -9,14 +9,14 @@ dependencies:
   - fastai=2.5.0
   - geos=3.9.1
   - geotiff=1.6.0
-  - h5py=2.10.0
+  - h5py=3.1.0
   - imageio=2.9.0
-  - keras=2.4.3
+  - keras=2.6.0
   - loguru=0.5.3
   - mkl=2020.4
   - numpy=1.20.3
   - numba=0.54.1
-  - pandas=1.3.1
+  - pandas=1.2.5
   - pillow=8.2.0
   - pip=20.3.4
   - pydantic=1.8.2

--- a/runtime/environment-gpu.yml
+++ b/runtime/environment-gpu.yml
@@ -14,7 +14,7 @@ dependencies:
   - geotiff=1.6.0
   - h5py=2.10.0
   - imageio=2.9.0
-  - keras=2.4.3
+  - keras=2.6.0
   - loguru=0.5.3
   - mkl=2020.4
   - numpy=1.20.3

--- a/runtime/environment-gpu.yml
+++ b/runtime/environment-gpu.yml
@@ -12,14 +12,14 @@ dependencies:
   - fastai=2.5.0
   - geos=3.9.1
   - geotiff=1.6.0
-  - h5py=2.10.0
+  - h5py=3.1.0
   - imageio=2.9.0
   - keras=2.6.0
   - loguru=0.5.3
   - mkl=2020.4
   - numpy=1.20.3
   - numba=0.54.1
-  - pandas=1.3.1
+  - pandas=1.2.5
   - pillow=8.2.0
   - pip=20.3.4
   - pydantic=1.8.2

--- a/runtime/tests/test_packages.py
+++ b/runtime/tests/test_packages.py
@@ -9,15 +9,16 @@ import pytest
 packages = [
     # these are problem libraries that don't always seem to import, mostly due
     # to dependencies outside the python world
-    "rasterio",
-    "xarray",
     "fastai",
-    "pandas",
+    "keras",
     "numpy",
-    "torch",  # pytorch
-    "sklearn",  # scikit-learn
+    "pandas",
+    "rasterio",
     "scipy",
+    "sklearn",  # scikit-learn
     "tensorflow",
+    "torch",  # pytorch
+    "xarray",
 ]
 
 


### PR DESCRIPTION
https://community.drivendata.org/t/error-when-importing-keras/6842/2

Keras does not work properly in the current runtime:

> E tensorflow/core/lib/monitoring/collection_registry.cc:77] Cannot register 2 metrics with the same name: /tensorflow/api/keras/optimizers
tensorflow.python.framework.errors_impl.AlreadyExistsError: Another metric with the same name already exists.